### PR TITLE
cleanup package.json `files` entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
   },
   "files": [
     "index.js",
-    "cli.js",
-    "vendor/nircmdc.exe"
+    "cli.js"
   ],
   "keywords": [
     "cli-app",


### PR DESCRIPTION
`vendor/nircmdc.exe` got removed in 37393f498f34ee0d45eba774c9f869b8d7d368de